### PR TITLE
feat: Make bottom margin customizable and change only when necessary

### DIFF
--- a/include/internal/QCodeEditor.hpp
+++ b/include/internal/QCodeEditor.hpp
@@ -106,6 +106,11 @@ class QCodeEditor : public QTextEdit
     void setAutoRemoveParentheses(bool enabled);
 
     /**
+     * @brief Method for setting extra bottom margin enabled.
+     */
+    void setExtraBottomMargin(bool enabled);
+
+    /**
      * @brief Method for getting is auto indentation enabled.
      * Default: true
      */
@@ -368,6 +373,7 @@ class QCodeEditor : public QTextEdit
     bool m_autoParentheses;
     bool m_replaceTab;
     bool m_autoRemoveParentheses;
+    bool m_extraBottomMargin;
     QString m_tabReplace;
 
     QList<QTextEdit::ExtraSelection> extra1, extra2, extra_squiggles;

--- a/src/internal/QCodeEditor.cpp
+++ b/src/internal/QCodeEditor.cpp
@@ -29,7 +29,8 @@ static QVector<QPair<QString, QString>> parentheses = {{"(", ")"}, {"{", "}"}, {
 QCodeEditor::QCodeEditor(QWidget *widget)
     : QTextEdit(widget), m_highlighter(nullptr), m_syntaxStyle(nullptr), m_lineNumberArea(new QLineNumberArea(this)),
       m_completer(nullptr), m_autoIndentation(true), m_autoParentheses(true), m_replaceTab(true),
-      m_autoRemoveParentheses(true), m_tabReplace(QString(4, ' ')), extra1(), extra2(), extra_squiggles(), m_squiggler()
+      m_autoRemoveParentheses(true), m_extraBottomMargin(true), m_tabReplace(QString(4, ' ')), extra1(), extra2(),
+      extra_squiggles(), m_squiggler()
 {
     initFont();
     performConnections();
@@ -144,9 +145,15 @@ void QCodeEditor::updateBottomMargin()
         // calling QTextFrame::setFrameFormat with an empty document makes the application crash
         auto rf = doc->rootFrame();
         auto format = rf->frameFormat();
-        int margin = doc->documentMargin();
-        format.setBottomMargin(qMax(margin, viewport()->height() - fontMetrics().height()) - margin);
-        rf->setFrameFormat(format);
+        int documentMargin = doc->documentMargin();
+        int bottomMargin = m_extraBottomMargin
+                               ? qMax(documentMargin, viewport()->height() - fontMetrics().height()) - documentMargin
+                               : documentMargin;
+        if (format.bottomMargin() != bottomMargin)
+        {
+            format.setBottomMargin(bottomMargin);
+            rf->setFrameFormat(format);
+        }
     }
 }
 
@@ -811,6 +818,12 @@ void QCodeEditor::setAutoIndentation(bool enabled)
 void QCodeEditor::setAutoRemoveParentheses(bool enabled)
 {
     m_autoRemoveParentheses = enabled;
+}
+
+void QCodeEditor::setExtraBottomMargin(bool enabled)
+{
+    m_extraBottomMargin = enabled;
+    updateBottomMargin();
 }
 
 bool QCodeEditor::autoIndentation() const


### PR DESCRIPTION
Because changing the text frame format affects the undo history, and we can't access the undo stack of a QTextDocument, the best solution is to make it customizable, and change the format only when necessary.