### PR TITLE
fix: Process Shift+Enter as pure Enter

### DIFF
--- a/src/internal/QCodeEditor.cpp
+++ b/src/internal/QCodeEditor.cpp
@@ -610,7 +610,7 @@ void QCodeEditor::keyPressEvent(QKeyEvent *e)
 
     if (!completerSkip)
     {
-        if ((e->key() == Qt::Key_Return || e->key() == Qt::Key_Enter))
+        if ((e->key() == Qt::Key_Return || e->key() == Qt::Key_Enter) && e->modifiers() != Qt::NoModifier)
         {
             QKeyEvent pureEnter(QEvent::KeyPress, Qt::Key_Enter, Qt::NoModifier);
             if (e->modifiers() == Qt::ControlModifier)
@@ -634,6 +634,11 @@ void QCodeEditor::keyPressEvent(QKeyEvent *e)
                     moveCursor(QTextCursor::EndOfBlock);
                     keyPressEvent(&pureEnter);
                 }
+                return;
+            }
+            else if (e->modifiers() == Qt::ShiftModifier)
+            {
+                keyPressEvent(&pureEnter);
                 return;
             }
         }


### PR DESCRIPTION
Before this commit, Shift+Enter adds a new line in the same block, and result in a wrong line number. It is somehow fine if only the line number is wrong, but with the language server, the squiggles are also in the wrong place, thus it's necessary to fix this.