### PR TITLE
perf: fix the performance issue of the line number area

### DIFF
--- a/src/internal/QLineNumberArea.cpp
+++ b/src/internal/QLineNumberArea.cpp
@@ -23,17 +23,14 @@ QSize QLineNumberArea::sizeHint() const
         return QWidget::sizeHint();
     }
 
-    int space = 0;
-    int lineCount = m_codeEditParent->document()->blockCount();
+    const int digits = QString::number(m_codeEditParent->document()->blockCount()).length();
+    int space;
 
-    for (int i = 0; i <= lineCount; ++i)
-    {
 #if QT_VERSION >= 0x050B00
-        space = 15 + m_codeEditParent->fontMetrics().horizontalAdvance(QString::number(i));
+    space = 15 + m_codeEditParent->fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
 #else
-        space = 15 + m_codeEditParent->fontMetrics().width(QLatin1Char(QString::number(i)));
+    space = 15 + m_codeEditParent->fontMetrics().width(QLatin1Char('9')) * digits;
 #endif
-    }
 
     return {space, 0};
 }


### PR DESCRIPTION
This fixes #26.

4b981c4 will be used in CP Editor 6.5.4, the master after merging this will be used in CP Editor 6.6.3, and the new editor instead of QCodeEditor will be used in CP Editor v6.7+.