### PR TITLE
Add Vim Cursor

### DIFF
--- a/include/internal/QCodeEditor.hpp
+++ b/include/internal/QCodeEditor.hpp
@@ -143,6 +143,16 @@ class QCodeEditor : public QTextEdit
      */
     void clearSquiggle();
 
+    /**
+     * @brief Enables or disables Vim Like cursor
+     */
+    void setVimCursor(bool value);
+
+    /**
+     * @brief Checks if cursor type is Vim Cursor
+     */
+    bool vimCursor() const;
+
   Q_SIGNALS:
     /**
      * @brief Signal, the font is changed by the wheel event.
@@ -384,10 +394,11 @@ class QCodeEditor : public QTextEdit
     bool m_autoIndentation;
     bool m_replaceTab;
     bool m_extraBottomMargin;
+    bool m_vimCursor;
     QString m_tabReplace;
 
     QList<QTextEdit::ExtraSelection> extra1, extra2, extra_squiggles;
-
+    QRect m_cursorRect;
     QVector<SquiggleInformation> m_squiggler;
 
     QVector<Parenthesis> m_parentheses;


### PR DESCRIPTION
Vim Cursor is a rectangle with the character inside of it. This commit adds a member function called `setVimCursor()` and `vimCursor()` that sets and retrieves the cursor type the QCodeEditor is presenting. This cursor is only visible when FakeVim is attached to the Editor. The Rectangle is visible when in Normal/Visual mode and a zero width line is visible when in insert mode.