### PR TITLE
refactor: small code improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# EditorConfig file (https://editorconfig.org) for the QCodeEditor project
+
+root = true
+
+[*]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# QCodeEditor C++ files
+[**.cpp]
+indent_style = space
+indent_size = 4
+[**.hpp]
+indent_style = space
+indent_size = 2
+
+# QCodeEditor XML files
+[**.xml]
+indent_style = space
+indent_size = 4
+[**.qrc]
+indent_style = space
+indent_size = 4
+
+# QCodeEditor CMake files
+[CMakeLists.txt]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+build/
 cmake-build-debug/
 cmake-build-release/
 .idea/
+.kdev4/
+QCodeEditor.kdev4
 *~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ set(CMAKE_CXX_STANDARD 11)
 option(BUILD_EXAMPLE "Example building required" Off)
 
 if (${BUILD_EXAMPLE})
-   message(STATUS "QCodeEditor example will be built.")
-   add_subdirectory(example)
+    message(STATUS "QCodeEditor example will be built.")
+    add_subdirectory(example)
 endif()
 
 set(RESOURCES_FILE
@@ -77,6 +77,9 @@ set(CMAKE_AUTOMOC On)
 # Create code from resource files
 set(CMAKE_AUTORCC ON)
 
+# Generate compile_commands.json in build/ for analyzers like clang-tidy.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Find includes in corresponding build directories
 find_package(Qt5Core    CONFIG REQUIRED)
 find_package(Qt5Widgets CONFIG REQUIRED)
@@ -94,16 +97,16 @@ target_include_directories(QCodeEditor PUBLIC
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(QCodeEditor
-		PRIVATE
-		-ansi
-		-pedantic
-		-Wall
-		-Wextra
-		-Weffc++
-		-Woverloaded-virtual
-		-Winit-self
-		-Wunreachable-code
-	)
+        PRIVATE
+        -ansi
+        -pedantic
+        -Wall
+        -Wextra
+        -Weffc++
+        -Woverloaded-virtual
+        -Winit-self
+        -Wunreachable-code
+    )
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
 target_link_libraries(QCodeEditor

--- a/include/internal/QCodeEditor.hpp
+++ b/include/internal/QCodeEditor.hpp
@@ -34,8 +34,7 @@ class QCodeEditor : public QTextEdit
         QChar left, right;
         bool autoComplete, autoRemove, tabJumpOut;
 
-        Parenthesis(const QChar &l = '(', const QChar &r = ')', bool complete = true, bool remove = true,
-                    bool jumpout = true)
+        Parenthesis(QChar l = '(', QChar r = ')', bool complete = true, bool remove = true, bool jumpout = true)
             : left(l), right(r), autoComplete(complete), autoRemove(remove), tabJumpOut(jumpout)
         {
         }
@@ -170,7 +169,7 @@ class QCodeEditor : public QTextEdit
      * part of line number area.
      * @param rect Area that has to be updated.
      */
-    void updateLineNumberArea(const QRect &rect);
+    void updateLineNumberArea(QRect rect);
 
     /**
      * @brief Slot, that will proceed extra selection

--- a/include/internal/QCodeEditor.hpp
+++ b/include/internal/QCodeEditor.hpp
@@ -136,7 +136,7 @@ class QCodeEditor : public QTextEdit
      * @note QPair<int, int>: first -> Line number in 1-based indexing
      *                        second -> Character number in 0-based indexing
      */
-    void squiggle(SeverityLevel level, QPair<int, int>, QPair<int, int>, QString tooltipMessage);
+    void squiggle(SeverityLevel level, QPair<int, int>, QPair<int, int>, const QString &tooltipMessage);
 
     /**
      * @brief clearSquiggle, Clears complete squiggle from editor
@@ -156,7 +156,7 @@ class QCodeEditor : public QTextEdit
      * completion info into code.
      * @param s Data.
      */
-    void insertCompletion(QString s);
+    void insertCompletion(const QString &s);
 
     /**
      * @brief Slot, that performs update of
@@ -366,7 +366,7 @@ class QCodeEditor : public QTextEdit
     {
         SquiggleInformation() = default;
 
-        SquiggleInformation(QPair<int, int> start, QPair<int, int> stop, QString text)
+        SquiggleInformation(QPair<int, int> start, QPair<int, int> stop, const QString &text)
             : m_startPos(start), m_stopPos(stop), m_tooltipText(text)
         {
         }

--- a/include/internal/QStyleSyntaxHighlighter.hpp
+++ b/include/internal/QStyleSyntaxHighlighter.hpp
@@ -11,6 +11,8 @@ class QSyntaxStyle;
  */
 class QStyleSyntaxHighlighter : public QSyntaxHighlighter
 {
+    Q_OBJECT
+
   public:
     /**
      * @brief Constructor.

--- a/include/internal/QSyntaxStyle.hpp
+++ b/include/internal/QSyntaxStyle.hpp
@@ -27,7 +27,7 @@ class QSyntaxStyle : public QObject
      * @param fl Style.
      * @return Success.
      */
-    bool load(QString fl);
+    bool load(const QString &fl);
 
     /**
      * @brief Method for getting style name.
@@ -47,7 +47,7 @@ class QSyntaxStyle : public QObject
      * @param name Property name.
      * @return Text char format.
      */
-    QTextCharFormat getFormat(QString name) const;
+    QTextCharFormat getFormat(const QString &name) const;
 
     /**
      * @brief Static method for getting default style.

--- a/src/internal/QCodeEditor.cpp
+++ b/src/internal/QCodeEditor.cpp
@@ -881,7 +881,13 @@ bool QCodeEditor::tabReplace() const
 void QCodeEditor::setTabReplaceSize(int val)
 {
     m_tabReplace.fill(' ', val);
+#if QT_VERSION >= 0x050B00
     setTabStopDistance(fontMetrics().horizontalAdvance(QString(val * 1000, ' ')) / 1000.0);
+#elif QT_VERSION == 0x050A00
+    setTabStopDistance(fontMetrics().width(QString(val * 1000, ' ')) / 1000.0);
+#else
+    setTabStopWidth(fontMetrics().width(QString(val * 1000, ' ')) / 1000.0);
+#endif
 }
 
 int QCodeEditor::tabReplaceSize() const

--- a/src/internal/QCodeEditor.cpp
+++ b/src/internal/QCodeEditor.cpp
@@ -101,9 +101,7 @@ void QCodeEditor::updateStyle()
         QString selectionBackground = m_syntaxStyle->getFormat("Selection").background().color().name();
 
         setStyleSheet(QString("QTextEdit { background-color: %1; selection-background-color: %2; color: %3; }")
-                          .arg(backgroundColor)
-                          .arg(selectionBackground)
-                          .arg(textColor));
+                          .arg(backgroundColor, selectionBackground, textColor));
     }
 
     updateExtraSelection1();

--- a/src/internal/QCodeEditor.cpp
+++ b/src/internal/QCodeEditor.cpp
@@ -682,7 +682,7 @@ void QCodeEditor::keyPressEvent(QKeyEvent *e)
             }
 
             auto c = charUnderCursor();
-            for (auto p : m_parentheses)
+            for (auto p : qAsConst(m_parentheses))
             {
                 if (p.tabJumpOut && c == p.right)
                 {
@@ -742,7 +742,7 @@ void QCodeEditor::keyPressEvent(QKeyEvent *e)
         {
             auto pre = charUnderCursor(-1);
             auto nxt = charUnderCursor();
-            for (auto p : m_parentheses)
+            for (auto p : qAsConst(m_parentheses))
             {
                 if (p.autoRemove && p.left == pre && p.right == nxt)
                 {
@@ -782,7 +782,7 @@ void QCodeEditor::keyPressEvent(QKeyEvent *e)
             }
         }
 
-        for (auto p : m_parentheses)
+        for (auto p : qAsConst(m_parentheses))
         {
             if (p.autoComplete)
             {
@@ -937,7 +937,7 @@ bool QCodeEditor::event(QEvent *event)
         QPair<int, int> positionOfTooltip{lineNumber, blockPositionStart};
 
         QString text;
-        for (auto const &e : m_squiggler)
+        for (auto const &e : qAsConst(m_squiggler))
         {
             if (e.m_startPos <= positionOfTooltip && e.m_stopPos >= positionOfTooltip)
             {

--- a/src/internal/QCodeEditor.cpp
+++ b/src/internal/QCodeEditor.cpp
@@ -51,7 +51,7 @@ void QCodeEditor::performConnections()
     connect(document(), &QTextDocument::blockCountChanged, this, &QCodeEditor::updateLineNumberAreaWidth);
     connect(document(), &QTextDocument::blockCountChanged, this, &QCodeEditor::updateBottomMargin);
 
-    connect(verticalScrollBar(), &QScrollBar::valueChanged, [this](int) { m_lineNumberArea->update(); });
+    connect(verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int) { m_lineNumberArea->update(); });
 
     connect(this, &QTextEdit::cursorPositionChanged, this, &QCodeEditor::updateExtraSelection1);
     connect(this, &QTextEdit::selectionChanged, this, &QCodeEditor::updateExtraSelection2);

--- a/src/internal/QCodeEditor.cpp
+++ b/src/internal/QCodeEditor.cpp
@@ -181,7 +181,7 @@ void QCodeEditor::updateLineNumberAreaWidth(int)
     setViewportMargins(m_lineNumberArea->sizeHint().width(), 0, 0, 0);
 }
 
-void QCodeEditor::updateLineNumberArea(const QRect &rect)
+void QCodeEditor::updateLineNumberArea(QRect rect)
 {
     m_lineNumberArea->update(0, rect.y(), m_lineNumberArea->sizeHint().width(), rect.height());
     updateLineGeometry();

--- a/src/internal/QCodeEditor.cpp
+++ b/src/internal/QCodeEditor.cpp
@@ -960,7 +960,7 @@ bool QCodeEditor::event(QEvent *event)
     return QTextEdit::event(event);
 }
 
-void QCodeEditor::insertCompletion(QString s)
+void QCodeEditor::insertCompletion(const QString &s)
 {
     if (m_completer->widget() != this)
     {
@@ -978,7 +978,8 @@ QCompleter *QCodeEditor::completer() const
     return m_completer;
 }
 
-void QCodeEditor::squiggle(SeverityLevel level, QPair<int, int> start, QPair<int, int> stop, QString tooltipMessage)
+void QCodeEditor::squiggle(SeverityLevel level, QPair<int, int> start, QPair<int, int> stop,
+                           const QString &tooltipMessage)
 {
     if (stop < start)
         return;

--- a/src/internal/QSyntaxStyle.cpp
+++ b/src/internal/QSyntaxStyle.cpp
@@ -10,7 +10,7 @@ QSyntaxStyle::QSyntaxStyle(QObject *parent) : QObject(parent), m_name(), m_data(
 {
 }
 
-bool QSyntaxStyle::load(QString fl)
+bool QSyntaxStyle::load(const QString &fl)
 {
     QXmlStreamReader reader(fl);
 
@@ -119,7 +119,7 @@ QString QSyntaxStyle::name() const
     return m_name;
 }
 
-QTextCharFormat QSyntaxStyle::getFormat(QString name) const
+QTextCharFormat QSyntaxStyle::getFormat(const QString &name) const
 {
     auto result = m_data.find(name);
 


### PR DESCRIPTION
As your fork of QCodeEditor is the only one that is somewhat maintained (although deprecated) and receives pull requests, I'd appreciate it if you merge my changes so that our forks are in sync.

What I've done:
- Fix various clazy warnings.
- Let CMake generate a `compile_commands.json` for other static code analysis tools.
- Add a `.editorconfig` to reflect the different indentation sizes.
- Update `.gitignore` for the use of kdevelop.
- Add suppport for older Qt versions (>= 5.7)

Please let me know what you think. Maybe you f.e. prefer pull requests for the individual changes?