### PR TITLE
build: update to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.6)
 project(QCodeEditor)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 option(BUILD_EXAMPLE "Example building required" Off)
 


### PR DESCRIPTION
1. https://invent.kde.org/qt/qt/qtbase/-/commit/6e8ad7201826e75601d902eea741380e37222fc7
   requires C++14, which is in the Arch qt5-base package.
2. Prepare for the Qt 6 migration in the future.