### PR TITLE
fix: move to first non-blank char on QKeySequence::MoveToStartOfLine

### DIFF
--- a/src/internal/QCodeEditor.cpp
+++ b/src/internal/QCodeEditor.cpp
@@ -848,6 +848,21 @@ void QCodeEditor::keyPressEvent(QKeyEvent *e)
             setTextCursor(cursor);
         }
 
+        if (e->matches(QKeySequence::MoveToStartOfLine))
+        {
+            auto cursor = textCursor();
+            auto line = cursor.block().text();
+            auto leadingSpaceCount = QRegularExpression("^\\s*").match(line).capturedLength();
+            auto cursorPos = cursor.positionInBlock();
+            if (cursorPos > leadingSpaceCount)
+                cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::MoveAnchor,
+                                    cursorPos - leadingSpaceCount);
+            else
+                cursor.movePosition(QTextCursor::StartOfBlock);
+            setTextCursor(cursor);
+            return;
+        }
+
         QTextEdit::keyPressEvent(e);
     }
 


### PR DESCRIPTION
This fixes cpeditor/cpeditor#774.